### PR TITLE
Change Log Update (00.00.25)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 
+Change Log Update (00.00.25)
+* 2016-03-24
++ mod_logon now has the initial read/write of module specific text prompts
+  basic setup will check on creation of class if file exists, if not it will create
+  with defaults.  The Module will load each prompt file on startup so to minimize disk i/o
+  when grabbing different prompts throughout the lifetime of the object.
+- Should create a global text prompt handler as well.  Things like Pause, or hit a key
+  and other misc text prompts should not be duplicated across modules.
+  
 Change Log Update (00.00.24)
 * 2016-03-24
 + Created new text_prompt_dao to handle reading and writing prompts for all modules

--- a/src/data/text_prompts_dao.hpp
+++ b/src/data/text_prompts_dao.hpp
@@ -3,10 +3,13 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <boost/smart_ptr/shared_ptr.hpp>
+
 #include <iostream>
 #include <fstream>
 #include <string>
 #include <map>
+
 
 // Types for Text Prompt formatting to file.
 typedef std::map<std::string, std::pair<std::string, std::string> > M_TextPrompt;
@@ -27,6 +30,12 @@ public:
     ~TextPromptsDao();
 
     /**
+     * @brief Check if the file exists and we need to create a new one.
+     * @return
+     */
+    bool fileExists();
+
+    /**
      * @brief Helper, appends forward/backward slash to path
      * @param value
      */
@@ -38,12 +47,19 @@ public:
      */
     void writeValue(M_TextPrompt &value);
 
+
+    /**
+     * @brief Read in the prompt file to the class.
+     * @return
+     */
+    bool readPrompts();
+
     /**
      * @brief Retrieves Desc, Text Pair of Text Prompt from yaml file.
      * @param lookup
      * @return
      */
-    M_StringPair getPrompt(std::string &lookup);
+    M_StringPair getPrompt(const std::string &lookup);
 
     /**
      * @brief Testing, display all nodes in a file.
@@ -53,7 +69,12 @@ public:
 
     std::string m_path;
     std::string m_filename;
+    bool        m_is_loaded;
+
+    YAML::Node  m_node;
 
 };
+
+typedef boost::shared_ptr<TextPromptsDao> text_prompts_dao_ptr;
 
 #endif // TEXT_PROMPTS_DAO_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#include "data/text_prompts_dao.hpp"
+
 #include "model/config.hpp"
 #include "data/config_dao.hpp"
 
@@ -31,6 +33,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <thread>
+#include <map>
 
 // temp
 #include <fstream>
@@ -196,6 +199,7 @@ auto main() -> int
     GLOBAL_DATA_PATH = GLOBAL_BBS_PATH + "DATA";
     GLOBAL_MENU_PATH = GLOBAL_BBS_PATH + "MENU";
     GLOBAL_TEXTFILE_PATH = GLOBAL_BBS_PATH + "TEXTFILE";
+
 
     // start io_service.run( ) in separate thread
     auto t = std::thread(&run, std::ref(io_service));

--- a/src/mods/mod_logon.cpp
+++ b/src/mods/mod_logon.cpp
@@ -1,11 +1,7 @@
 #include "mod_logon.hpp"
 
-#include <yaml-cpp/yaml.h>
-
 #include <iostream>
 #include <string>
-
-
 
 
 /**
@@ -16,13 +12,13 @@ bool ModLogon::update(const std::string &character_buffer, const bool &)
 {
     // Make sure system is active, when system is done, success or failes
     // We change this is inactive to single the login process is completed.
-    if (!m_is_active)
+    if(!m_is_active)
     {
         return false;
     }
 
     // Return True when were keeping module active / else false;
-    if (character_buffer.size() == 0)
+    if(character_buffer.size() == 0)
     {
         return true;
     }
@@ -50,7 +46,7 @@ bool ModLogon::update(const std::string &character_buffer, const bool &)
         // Send back the single input received TESTING
         m_session_data->deliver(result);
     }
-  
+
     return true;
 }
 
@@ -63,11 +59,10 @@ bool ModLogon::onEnter()
     std::cout << "OnEnter() ModLogin\n";
     m_is_active = true;
 
+    // Grab ANSI Screen, display, if desired.. logon.ans maybe?
+
+    // Execure the initial setup index.
     m_setup_functions[m_mod_function_index]();
-
-    // Grab ANSI Screen, display,
-
-    // Read in Text Prompts, display.
 
     return true;
 }
@@ -81,6 +76,20 @@ bool ModLogon::onExit()
     std::cout << "OnExit() ModLogin\n";
     m_is_active = false;
     return true;
+}
+
+/**
+ * @brief Create Default Text Prompts for module
+ */
+void ModLogon::createTextPrompts()
+{
+
+    // Create Mapping to pass for file creation (default values)
+    M_TextPrompt value;
+    value[PROMPT_LOGON]    = std::make_pair("Displayed for Logon Prompt", "|15Logon: ");
+    value[PROMPT_PASSWORD] = std::make_pair("Displayed for Password Prompt", "|15password: ");
+
+    m_text_prompts_dao->writeValue(value);
 }
 
 
@@ -102,6 +111,17 @@ void ModLogon::changeModule(int mod_function_index)
  */
 void ModLogon::setupLogon()
 {
+
+    std::cout << "setupLogon()" << std::endl;
+
+    // Testing.
+    m_text_prompts_dao->displayAll();
+
+    // Test display
+
+    M_StringPair result = m_text_prompts_dao->getPrompt(PROMPT_PASSWORD);
+
+    std::cout << "TEST: " << result.first << ", " << result.second << std::endl;
 
 }
 
@@ -152,7 +172,7 @@ void ModLogon::setupNewUserApplication()
 bool ModLogon::logon(const std::string &input)
 {
     bool result = false;
-    if (input.size() != 0)
+    if(input.size() != 0)
     {
 
     }
@@ -168,7 +188,7 @@ bool ModLogon::logon(const std::string &input)
 bool ModLogon::password(const std::string &input)
 {
     bool result = false;
-    if (input.size() != 0)
+    if(input.size() != 0)
     {
 
     }
@@ -183,7 +203,7 @@ bool ModLogon::password(const std::string &input)
 bool ModLogon::passwordChallenge(const std::string &input)
 {
     bool result = false;
-    if (input.size() != 0)
+    if(input.size() != 0)
     {
 
     }
@@ -198,7 +218,7 @@ bool ModLogon::passwordChallenge(const std::string &input)
 bool ModLogon::passwordChange(const std::string &input)
 {
     bool result = false;
-    if (input.size() != 0)
+    if(input.size() != 0)
     {
 
     }
@@ -213,7 +233,7 @@ bool ModLogon::passwordChange(const std::string &input)
 bool ModLogon::newUserApplication(const std::string &input)
 {
     bool result = false;
-    if (input.size() != 0)
+    if(input.size() != 0)
     {
 
     }


### PR DESCRIPTION
* 2016-03-24
+ mod_logon now has the initial read/write of module specific text
prompts
basic setup will check on creation of class if file exists, if not it
will create
with defaults.  The Module will load each prompt file on startup so to
minimize disk i/o
when grabbing different prompts throughout the lifetime of the object.
- Should create a global text prompt handler as well.  Things like
Pause, or hit a key
and other misc text prompts should not be duplicated across modules.