### PR TITLE
Change Log Update (00.00.26)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 
+Change Log Update (00.00.26)
+* 2016-03-24
++ Created global prompt that are shared system wide, they are accessed via the communicator object
+  for easy of use and access, global prompt keys are created in the data/structures file
+  while each module with have it's specific in their own mod_xxx.hpp file.
+
 Change Log Update (00.00.25)
 * 2016-03-24
 + mod_logon now has the initial read/write of module specific text prompts

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -1,5 +1,6 @@
 #include "communicator.hpp"
 
+#include "model/structures.hpp"
 #include "model/struct_compat.hpp"
 
 #include <iostream>
@@ -9,15 +10,28 @@
 /**
  * @brief  Global Singleton Instance, needed to initalize the class.
  */
-Communicator* Communicator::m_globalInstance = nullptr;
+Communicator* Communicator::m_global_instance = nullptr;
 
 /**
  * @brief Default Constructors required.
  * @return
  */
 Communicator::Communicator()
+    : m_filename("mod_global.yaml")
+    , m_text_prompts_dao(new TextPromptsDao(GLOBAL_DATA_PATH, m_filename))
+    , m_is_text_prompt_exist(false)
 {
     std::cout << "Communicator" << std::endl;
+
+    // Check of the Text Prompts exist.
+    m_is_text_prompt_exist = m_text_prompts_dao->fileExists();
+    if(!m_is_text_prompt_exist)
+    {
+        createTextPrompts();
+    }
+
+    // Loads all Text Prompts for current module
+    m_text_prompts_dao->readPrompts();
 }
 
 Communicator::~Communicator()

--- a/src/model/structures.hpp
+++ b/src/model/structures.hpp
@@ -4,10 +4,15 @@
 
 #include <string>
 
-extern std::string BBS_PATH;  // BBS System
-extern std::string DATA_PATH; // OBV/2 Data Files
-extern std::string MENU_PATH; // OBV/2 Data Files
-extern std::string TEXTFILE_PATH; // OBV/2 Data Files
+extern std::string GLOBAL_BBS_PATH;      // BBS System
+extern std::string GLOBAL_DATA_PATH;
+extern std::string GLOBAL_MENU_PATH;
+extern std::string GLOBAL_TEXTFILE_PATH;
+
+/**
+ * @brief Const Key values for global text prompt lookup
+ */
+const std::string GLOBAL_PROMPT_PAUSE = "pause";
 
 /**
  * @brief List of interfaces for pipe2ansi conversion


### PR DESCRIPTION
* 2016-03-24
+ Created global prompt that are shared system wide, they are accessed
via the communicator object
for easy of use and access, global prompt keys are created in the
data/structures file
while each module with have it's specific in their own mod_xxx.hpp file.