### PR TITLE
Change Log Update (00.00.29)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,17 @@
 
+Change Log Update (00.00.29)
+* 2016-03-26
++ Prompts are not working for Terminal Detection (Telnet Option Parsing)
+  When completed, now displays detected terminal 'ansi' and size '80x25' etc..
++ Prelogon Emulation Detection is working, sending ESC[6n and getting a response
+  from the client,  ESC[xx;xxR for current X/Y Position showing the client 
+  can use ESC sequence
++ Also added a new Detection Timer for 1.5 seconds to receive client response
+  for ESC[6n query.
++ Prompts are now setup to show Emulation Detected results
+- Left off on asking for ANSI Color when detection fails
+- Left off on asking Encoding CP437 or UTF-8
+
 Change Log Update (00.00.28)
 * 2016-03-25
 + Created New Mod_PreLogon to handle pre-logon sequences like Emulation and Term Detection.

--- a/src/common_io.cpp
+++ b/src/common_io.cpp
@@ -1222,9 +1222,8 @@ std::string CommonIO::boolAlpha(bool value)
  * @param mcicode
  * @param replacement
  */
-void CommonIO::parseLocalMCI(std::string &AnsiString, std::string mcicode, std::string replacement)
+void CommonIO::parseLocalMCI(std::string &AnsiString, const std::string &mcicode, const std::string &replacement)
 {
-//    char szTmp[2]= {0};
     std::string::size_type id1 = 0;
     do
     {

--- a/src/common_io.hpp
+++ b/src/common_io.hpp
@@ -289,7 +289,7 @@ public:
      * @param mcicode
      * @param replacement
      */
-    void parseLocalMCI(std::string &AnsiString, std::string mcicode, std::string replacement);
+    void parseLocalMCI(std::string &AnsiString, const std::string &mcicode, const std::string &replacement);
 
     /**
      * @brief Read In ANSI text files for parsing.

--- a/src/communicator.hpp
+++ b/src/communicator.hpp
@@ -171,8 +171,10 @@ public:
 
         // Create Mapping to pass for file creation (default values)
         M_TextPrompt value;
-        value[GLOBAL_PROMPT_PAUSE]           = std::make_pair("Displayed for Pause Prompts", "Hit any Key -- OBV/2 XRM");
-        value[GLOBAL_PROMPT_DETECT_TERMOPTS] = std::make_pair("Detecting Terminal Options", "|08Detecting Terminal Options");
+        value[GLOBAL_PROMPT_PAUSE]            = std::make_pair("Displayed for Pause Prompts", "|03Hit any Key |08-- |03OBV/2 XRM");
+        value[GLOBAL_PROMPT_DETECT_TERMOPTS]  = std::make_pair("Detecting Terminal Options", "|CR|08|15 - |08Detecting Terminal Options |15-|08");
+        value[GLOBAL_PROMPT_DETECTED_TERM]    = std::make_pair("Detecting Terminal: |OT ", "|CR|08Detected Terminal: |04|OT |07");
+        value[GLOBAL_PROMPT_DETECTED_SIZE]    = std::make_pair("Detecting Terminal Size: |OT ", "|CR|08Detected Screen Size: |04|OT |07");
 
         m_text_prompts_dao->writeValue(value);
     }

--- a/src/model/structures.hpp
+++ b/src/model/structures.hpp
@@ -14,6 +14,8 @@ extern std::string GLOBAL_TEXTFILE_PATH;
  */
 const std::string GLOBAL_PROMPT_PAUSE = "pause";
 const std::string GLOBAL_PROMPT_DETECT_TERMOPTS = "detect_term";
+const std::string GLOBAL_PROMPT_DETECTED_TERM = "detected_term";
+const std::string GLOBAL_PROMPT_DETECTED_SIZE = "detected_size";
 
 
 /**

--- a/src/mods/mod_prelogon.cpp
+++ b/src/mods/mod_prelogon.cpp
@@ -97,11 +97,11 @@ void ModPreLogon::createTextPrompts()
     // Create Mapping to pass for file creation (default values)
     M_TextPrompt value;
 
-    value[PROMPT_DETECT_EMULATION] = std::make_pair("Detecting Emulation", "|08Detecting Emulation");
-    value[PROMPT_DETECTED_ANSI]    = std::make_pair("ANSI Emulation Detected", "|04E|12m|14ulation: An|12s|04i");
-    value[PROMPT_DETECTED_NONE]    = std::make_pair("Emulation Detect:None", "Emulation Detect:None");
+    value[PROMPT_DETECT_EMULATION] = std::make_pair("Detecting Emulation", "|CR|CR|15 - |08Detecting Emulation |15-");
+    value[PROMPT_DETECTED_ANSI]    = std::make_pair("ANSI Emulation Detected", "|CR|04E|12m|14ulation: An|12s|04i");
+    value[PROMPT_DETECTED_NONE]    = std::make_pair("Emulation Detect:None", "|CREmulation Detect: None");
 
-    value[PROMPT_USE_ANSI]         = std::make_pair("Use ANSI Colors (Y/n) ", "|D1|08Press [|15Y|08 or |15ENTER|08] to use ANSI : ");
+    value[PROMPT_USE_ANSI]         = std::make_pair("Use ANSI Colors (Y/n) ", "|CR|08Press [|15Y|08 or |15ENTER|08] to use ANSI : ");
 
     value[PROMPT_USE_CP437]        = std::make_pair("Use CP437 Output Encoding", "|D1|08[|15Y|08] Select MS-DOS CP-437 Output |CR|08[|15N|08] Select UTF-8 Terminal Output");
     value[PROMPT_USE_UTF8]         = std::make_pair("Use UTF-8 Output Encoding", "|D1|08[|15Y|08] Select UTF-8 Terminal Output |CR|08[|15N|08] Select MS-DOS CP-437 Output");
@@ -125,36 +125,43 @@ void ModPreLogon::changeModule(int mod_function_index)
 }
 
 /**
- * @brief Validates user Logon
+ * @brief Startup ANSI Emulation Detection.
  * @return
  */
 void ModPreLogon::setupEmulationDetection()
 {
-    std::cout << "setupPreLogon()" << std::endl;
+    std::cout << "setupEmulationDetection()" << std::endl;
 
     // Deliver ANSI Location Sequence
-    m_session_data->deliver("\x1b[255B\x1b[6n\x1b[1;1H");
+    m_session_data->deliver("\x1b[s\x1b[255B\x1b[6n\x1b[1;1H");
+    m_session_data->deliver("\x1b[u");
 
-    //M_StringPair prompt = m_text_prompts_dao->getPrompt(PROMPT_DETECT_EMULATION);
+    M_StringPair prompt = m_text_prompts_dao->getPrompt(PROMPT_DETECT_EMULATION);
     //std::cout << "TEST: " << prompt.first << ", " << prompt.second << std::endl;
-    //std::string result = m_session_io.pipe2ansi(prompt.second);
-
-    //m_session_data->deliver(result);
-}
-
-
-/*
-    M_StringPair prompt;
-
-PROMPT_DETECT_EMULATION
-    prompt = m_text_prompts_dao->getPrompt(PROMPT_DETECTED_ANSI);
-    prompt = m_text_prompts_dao->getPrompt(PROMPT_DETECTED_NONE);
-
-    std::cout << "TEST: " << prompt.first << ", " << prompt.second << std::endl;
     std::string result = m_session_io.pipe2ansi(prompt.second);
 
     m_session_data->deliver(result);
-*/
+
+    // Start Timeout for Detection.
+    startDetectionTimer();
+}
+
+
+/**
+ * @brief Ask to us ANSI Color {Only ask for color if emulation detection fails!}
+ * @return
+ */
+void ModPreLogon::setupAskANSIColor()
+{
+    std::cout << "setupAskANSIColor()" << std::endl;
+
+    // Ask to use colors - mode to next method to ask question and get reponse!
+    /*
+    prompt = m_text_prompts_dao->getPrompt(PROMPT_USE_ANSI);
+    std::cout << "TEST: " << prompt.first << ", " << prompt.second << std::endl;
+    std::string result = m_session_io.pipe2ansi(prompt.second);
+    m_session_data->deliver(result);*/
+}
 
 
 /**
@@ -163,42 +170,128 @@ PROMPT_DETECT_EMULATION
  */
 bool ModPreLogon::emulationDetection(const std::string &input)
 {
-
     bool result = false;
     if(input.size() != 0)
     {
-        std::cout << "prelogon response: " << input << std::endl;
+        std::cout << "emulationDetection" << input << std::endl;
 
-        m_input_buffer += input;
-        // Build up the buffer where the reply sequence.
+        unsigned int ch = 0;
+        ch = input[0];
 
-        /*
-
-        // Passthrough...
-        if(ch == 27 || ch == '^' || ch == '[') {}
-
-        // Get x[##;xx
-        if(isdigit(ch))
+        // Read in buffer once ESC sequence is hit to
+        // Parse the ESC[6n Response
+        if (ch == 27)
         {
-            xy[i] = ch;
-            ++i;
+            m_is_esc_detected = true;
         }
 
-        //now get x[xx;##
-        if(ch==';')
+        // Check for sequence terminator.
+        if (m_is_esc_detected)
         {
-            i = 0;
-            //memset(&xy,0,sizeof(xy));
-            ansi_x = atoi(xy);
+            if (toupper(ch) == 'R')
+            {
+                m_is_emulation_detected = true;
+            }
         }
-        //now get end of sequence.
-        if (toupper(ch) == 'R')
+
+        /* -- Get Secondary screen size detection for emulation response.
+         * -- Modem or virtual modem will not have Telnet Options negoiation
+         * -- So then we have to detect old fashion way with ESC response!
+        // Were inside sequence.
+        if (m_esc_detected)
         {
-            ansi_y = atoi(xy);
-            break;
+            // Get x[##;xx
+            if(isdigit(ch))
+            {
+                xy[i] = ch;
+                ++i;
+            }
+
+            //now get x[xx;##
+            if(ch==';')
+            {
+                i = 0;
+                m_x_position = atoi(xy);
+            }
+
+            //now get end of sequence.
+            if (toupper(ch) == 'R')
+            {
+                m_y_position = atoi(xy);
+
+                // Register we received a completed sequence.
+                m_is_emulation_detected = true;
+                break;
+            }
         }*/
-
     }
     return result;
 }
 
+/**
+ * @brief Detection Completed, display results.
+ * @return
+ */
+void ModPreLogon::emulationCompleted()
+{
+    std::cout << "emulationCompleted: " << std::endl;
+    // Reset to false so we can reuse for other methods.
+    m_is_esc_detected = false;
+
+    if (m_is_emulation_detected)
+    {
+        // Emulation Detected ANSI
+        M_StringPair prompt = m_text_prompts_dao->getPrompt(PROMPT_DETECTED_ANSI);
+        std::cout << "TEST: " << prompt.first << ", " << prompt.second << std::endl;
+        std::string result = m_session_io.pipe2ansi(prompt.second);
+        m_session_data->deliver(result);
+    }
+    else
+    {
+        // Emulation Detected NONE
+        M_StringPair prompt = m_text_prompts_dao->getPrompt(PROMPT_DETECTED_NONE);
+        std::cout << "TEST: " << prompt.first << ", " << prompt.second << std::endl;
+        std::string result = m_session_io.pipe2ansi(prompt.second);
+        m_session_data->deliver(result);
+
+        // Move to the next Method to ask to use ANSI Color
+        changeModule(MOD_ASK_ANSI_COLOR);
+    }
+
+}
+
+
+/**
+ * @brief ASK ANSI Color {Only ask for color if emulation detection fails!}
+ * @return
+ */
+bool ModPreLogon::askANSIColor(const std::string &input)
+{
+    std::cout << "askANSIColor: " << input << std::endl;
+
+    // handle input for using ansi color, hot key or ENTER after..  hmmm
+
+    /*
+    std::string input = "";
+    std::string result = m_session_io.getInputField(character_buffer, input);
+    if(result == "aborted") // ESC was hit, make this just clear the input text, or start over!
+    {
+        std::cout << "aborted!" << std::endl;
+    }
+    else if(result[0] == '\n')
+    {
+        // Send back the entire string.  TESTING
+        // This should then be processed becasue ENTER was hit.
+        //m_session_data->deliver(input);
+        m_session_data->deliver(result);
+
+        // Process the completed input for the string.
+        m_mod_functions[m_mod_function_index](input);
+    }
+    else
+    {
+        // Send back the single input received TESTING
+        m_session_data->deliver(result);
+    }*/
+    return true;
+}

--- a/src/session_data.hpp
+++ b/src/session_data.hpp
@@ -43,6 +43,7 @@ public:
         , m_telnet_state(new TelnetDecoder(connection))
         , m_input_deadline(io_service)
         , m_state_manager(state_manager)
+        , m_io_service(io_service)
         , m_user_record()
         , m_node_number(0)
         , m_input_encoding("cp437")
@@ -248,6 +249,7 @@ public:
     telnet_ptr            m_telnet_state;
     deadline_timer        m_input_deadline;
     state_manager_ptr     m_state_manager;
+    boost::asio::io_service& m_io_service;
 
     // Temp while testing.
     UserRec               m_user_record;

--- a/src/telnet_decoder.hpp
+++ b/src/telnet_decoder.hpp
@@ -109,6 +109,11 @@ public:
         return m_naws_col;
     }
 
+    std::string getTermType() const
+    {
+        return m_term_type;
+    }
+
 private:
 
     connection_ptr		m_connection;


### PR DESCRIPTION
* 2016-03-26
+ Prompts are not working for Terminal Detection (Telnet Option Parsing)
When completed, now displays detected terminal 'ansi' and size '80x25'
etc..
+ Prelogon Emulation Detection is working, sending ESC[6n and getting a
response
from the client,  ESC[xx;xxR for current X/Y Position showing the client

can use ESC sequence
+ Also added a new Detection Timer for 1.5 seconds to receive client
response
for ESC[6n query.
+ Prompts are now setup to show Emulation Detected results
- Left off on asking for ANSI Color when detection fails
- Left off on asking Encoding CP437 or UTF-8