### PR TITLE
Change Log Update (00.00.32)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,17 @@
 
+Change Log Update (00.00.32)
+* 2016-03-27
++ Completed Use Codepage selections in PreLogon Module.
++ PreLogon module is now completed with initial detection phases.
+  Moving on to the Logon Module for the Matrix login, and NewUser Module
+  for new user accounts.
++ Adding CR\LF replacement to LF on incoming data.  Windows Console Telnet
+  Likes to send CR\LF for [ENTER] instead of a single key.
+
 Change Log Update (00.00.31)
 * 2016-03-27
 + Working on more of the PreLogon process, When ANSI is not detected it will
-  ask to use colors or ascii no color.  Next need to work on codepage output
+  ask to use colors or ASCII no color.  Next need to work on codepage output
   CP437 or UTF-8.  
 - Also look at the NEW_ENV Telnet options when I get some more time.
 

--- a/src/mods/mod_prelogon.hpp
+++ b/src/mods/mod_prelogon.hpp
@@ -42,6 +42,7 @@ public:
         , m_input_buffer("")
         , m_x_position(0)
         , m_y_position(0)
+        , m_term_type("undetected")
     {
         std::cout << "ModPreLogon" << std::endl;
 
@@ -94,10 +95,10 @@ public:
     const std::string PROMPT_ANSI_SELECTED = "ansi_selected";
     const std::string PROMPT_ASCII_SELECTED = "ascii_selected";
 
-    const std::string PROMPT_USE_CP437 = "use_cp437";
-    const std::string PROMPT_USE_UTF8 = "use_utf8";
-    const std::string PROMPT_CODEPAGE_CP437 = "codepage_437";
-    const std::string PROMPT_CODEPAGE_UTF8 = "codepage_utf8";
+    const std::string PROMPT_ASK_CP437 = "use_cp437";
+    const std::string PROMPT_ASK_UTF8 = "use_utf8";
+    const std::string PROMPT_CP437_SELECTED = "cp437_selected";
+    const std::string PROMPT_UTF8_SELECTED = "utf8_selected";
 
 
     /**
@@ -197,6 +198,7 @@ private:
     std::string          m_input_buffer;
     int                  m_x_position;
     int                  m_y_position;
+    std::string          m_term_type;
 };
 
 #endif // SYSTEM_STATE_HPP

--- a/src/session_data.cpp
+++ b/src/session_data.cpp
@@ -30,6 +30,22 @@ void SessionData::handleRead(const boost::system::error_code& error, size_t byte
         {
             if(m_parsed_data.size() > 0)
             {
+                // Windows Console Telnet sends [CR\LF] for ENTER!
+                // search and replace input buffer we only need one!
+                std::string::size_type id1 = 0;
+                do
+                {
+                    // Convert CR\LF to LF!
+                    id1 = m_parsed_data.find("\r\n", 0);
+                    if(id1 != std::string::npos)
+                    {
+                        m_parsed_data.erase(id1, 1);
+                        id1 = m_parsed_data.find("\r\n", 0);
+                    }
+                }
+                while(id1 != std::string::npos);
+
+
                 // Last Character Received is ESC, then Check for
                 // ESC Sequence, or Lone ESC Key.
                 if(m_parsed_data[m_parsed_data.size()-1] == '\x1b')

--- a/src/session_io.cpp
+++ b/src/session_io.cpp
@@ -221,7 +221,7 @@ std::string SessionIO::getInputField(const std::string &character_buffer,
             }
         }
         // Check for Completed Field Entry
-        else if(string_data[0] == '\n' && string_data.size() == 1)
+        else if((string_data[0] == '\n' && string_data.size() == 1) || character_buffer[0] == '\n')
         {
             result = m_common_io.getInputBuffer();
             //std::cout << "Field: " << result << std::endl;
@@ -752,4 +752,34 @@ std::string SessionIO::pipe2ansi(const std::string &sequence, int interface)
     // Clear Codemap.
     std::vector<MapType>().swap(code_map);
     return ansi_string;
+}
+
+
+/**
+ * @brief Parses Text Prompt String Pair, if |D1 is found, pull description into prompt
+ * @param prompt
+ * @return
+ */
+std::string SessionIO::parseTextPrompt(const M_StringPair &prompt)
+{
+    // Looks like D1 is delay on not description for text prompts,
+    // Need to work on a timer displya procress for delays and
+    // long ansi screen scrolling that is async friends and will not hose
+    // up the system loop.  in these cases might need a thread?!?
+    // Delays can wait till more of the system it put togehter to test what
+    // works best with multiple users online and doing stuff.
+
+    /*
+    // handle to prompt
+    std::string text_prompt = prompt.second;
+    std::string mci_code = "|D1";
+
+    // If Description Flag is in Prompt, then replace code with Description
+    m_common_io.parseLocalMCI(text_prompt, mci_code, prompt.first);
+
+    // Return full mci code parsing on the new string.
+    return pipe2ansi(text_prompt);*/
+
+    std::string text_prompt = prompt.second;
+    return pipe2ansi(text_prompt);
 }

--- a/src/session_io.hpp
+++ b/src/session_io.hpp
@@ -18,6 +18,11 @@
 class SessionIO
 {
 public:
+
+    // Types for Text Prompt formatting to file.
+    typedef std::pair<std::string, std::string> M_StringPair;
+
+
     SessionIO(session_data_ptr session_data);
     ~SessionIO();
 
@@ -107,6 +112,14 @@ public:
      * @return
      */
     std::string pipe2ansi(const std::string &sequence, int interface = STANDARD_MCI);
+
+
+    /**
+     * @brief Parses Text Prompt String Pair, if |D1 is found, pull description into prompt
+     * @param prompt
+     * @return
+     */
+    std::string parseTextPrompt(const M_StringPair &prompt);
 
     // Internal Methods
     session_data_ptr m_session_data; // SessionData

--- a/src/telnet_decoder.hpp
+++ b/src/telnet_decoder.hpp
@@ -172,8 +172,6 @@ private:
             return;
         }
 
-        std::cout << "telnet: " << msg << std::endl;
-
         if(m_connection->is_open())
         {
             if(m_connection->m_is_secure)


### PR DESCRIPTION
* 2016-03-27
+ Completed Use Codepage selections in PreLogon Module.
+ PreLogon module is now completed with initial detection phases.
Moving on to the Logon Module for the Matrix login, and NewUser Module
for new user accounts.
+ Adding CR\LF replacement to LF on incoming data.  Windows Console
Telnet
Likes to send CR\LF for [ENTER] instead of a single key.